### PR TITLE
Speed up login action

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,6 +10,11 @@ var assert = require('assert');
 var request = require('supertest');
 
 _beforeEach.withApp = function(app) {
+  if (app.models.User) {
+    // Speed up the password hashing algorithm
+    app.models.User.settings.saltWorkFactor = 4;
+  }
+
   beforeEach(function() {
     this.app = app;
     var _request = this.request = request(app);


### PR DESCRIPTION
Decrease `User.settings.saltWorkFactor` in order to speed up tests that are creating and authenticating a user.

/to: @ritch  @raymondfeng please review.
/cc @rmg the change should fix the occasional failure of loopback test "access control - integration /accounts when called by logged in user" in "before each" hook.
