### PR TITLE
Remove juggler from peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "async": "~0.2.10"
   },
   "peerDependencies": {
-    "loopback": ">=1.6.1",
-    "loopback-datasource-juggler": "1.x"
+    "loopback": ">=1.6.1"
   },
   "devDependencies": {
     "chai": "~1.9.0",


### PR DESCRIPTION
As of #9, loopback-testing no longer `require()s` loopback directly.
Module users have to supply their loopback models by passing the
constructor to helper functions.

The reason for keeping loopback in peerDependencies is to control
which loopback version are compatible with loopback-testing.
To achieve that, loopback-datasource-juggler does not need to be
included in peerDependencies.

Close #8.

/to @ritch please review

My hope is that the change will reduce the likelihood of EPEERINVALID errors.
