### PR TITLE
Support loopback 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "async": "~0.2.10"
   },
   "peerDependencies": {
-    "loopback": "^1.6.1"
+    "loopback": "2.x || ^1.6.1"
   },
   "devDependencies": {
     "chai": "~1.9.0",


### PR DESCRIPTION
Fix peer dependency on loopback to include 2.x versions.

This fixes a problem introduced by f760cb0ad.

/cc @ritch 
