### PR TITLE
Drop peer dependency on loopback

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "mocha": "~1.17.1",
     "async": "~0.2.10"
   },
-  "peerDependencies": {
-    "loopback": "2.x || ^1.6.1"
-  },
   "devDependencies": {
     "chai": "~1.9.0",
     "loopback": "^1.6.1"


### PR DESCRIPTION
The peer dependency was used to control which loopback versions
we are compatible with. Unfortunately it does not work well, e.g.
even when the peer dep allows loopback 2.x, npm installs 1.x version
instead.

/to @ritch please review
