### PR TITLE
helpers: Improve ACL asserts

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -142,7 +142,12 @@ _beforeEach.givenAnAnonymousToken = function(attrs, optionalHandler) {
   _beforeEach.givenModel('accessToken', {id: '$anonymous'}, optionalHandler);
 }
 
-_describe.whenCalledRemotely = function(verb, url, cb) {
+_describe.whenCalledRemotely = function(verb, url, data, cb) {
+  if (cb == undefined) {
+    cb = data;
+    data = null;
+  }
+
   var urlStr = url;
   if(typeof url === 'function') {
     urlStr = '/<dynamic>';
@@ -165,6 +170,12 @@ _describe.whenCalledRemotely = function(verb, url, cb) {
       if(this.loggedInAccessToken) {
         this.http.set('authorization', this.loggedInAccessToken.id);
       }
+      if (data) {
+        var payload = data;
+        if (typeof data === 'function')
+          payload = data.call(this);
+        this.http.send(payload);
+      }
       this.req = this.http.req;
       var test = this;
       this.http.end(function(err) {
@@ -186,24 +197,24 @@ _describe.whenLoggedInAsUser = function(credentials, cb) {
   });
 }
 
-_describe.whenCalledByUser = function(credentials, verb, url, cb) {
+_describe.whenCalledByUser = function(credentials, verb, url, data, cb) {
   describe('when called by logged in user', function () {
     _beforeEach.givenLoggedInUser(credentials);
-    _describe.whenCalledRemotely(verb, url, cb);
+    _describe.whenCalledRemotely(verb, url, data, cb);
   });
 }
 
-_describe.whenCalledAnonymously = function(verb, url, cb) {
+_describe.whenCalledAnonymously = function(verb, url, data, cb) {
   describe('when called anonymously', function () {
     _beforeEach.givenAnAnonymousToken();
-    _describe.whenCalledRemotely(verb, url, cb);
+    _describe.whenCalledRemotely(verb, url, data, cb);
   });
 }
 
-_describe.whenCalledUnauthenticated = function(verb, url, cb) {
+_describe.whenCalledUnauthenticated = function(verb, url, data, cb) {
   describe('when called with unauthenticated token', function () {
     _beforeEach.givenAnAnonymousToken();
-    _describe.whenCalledRemotely(verb, url, cb);
+    _describe.whenCalledRemotely(verb, url, data, cb);
   });
 }
 
@@ -234,8 +245,8 @@ _it.shouldNotBeFound = function() {
 }
 
 _it.shouldBeAllowedWhenCalledAnonymously =
-function(verb, url) {
-  _describe.whenCalledAnonymously(verb, url, function() {
+function(verb, url, data) {
+  _describe.whenCalledAnonymously(verb, url, data, function() {
     _it.shouldBeAllowed();
   });
 }
@@ -248,8 +259,8 @@ function(verb, url) {
 }
 
 _it.shouldBeAllowedWhenCalledUnauthenticated =
-function(verb, url) {
-  _describe.whenCalledUnauthenticated(verb, url, function() {
+function(verb, url, data) {
+  _describe.whenCalledUnauthenticated(verb, url, data, function() {
     _it.shouldBeAllowed();
   });
 }
@@ -262,8 +273,8 @@ function(verb, url) {
 }
 
 _it.shouldBeAllowedWhenCalledByUser =
-function(credentials, verb, url) {
-  _describe.whenCalledByUser(credentials, verb, url, function() {
+function(credentials, verb, url, data) {
+  _describe.whenCalledByUser(credentials, verb, url, data, function() {
     _it.shouldBeAllowed();
   });
 }


### PR DESCRIPTION
Modify `_it.shouldBeAllowed` to include the actual status code
in the assertion error.

Modify `_it.shouldBeDenied` to assert the exact value of the status
code. Expect the status code configured via `app.get('aclErrorStatus')`,
add a parameter allowing callers to override this value.

Allow tests to send arbitrary request body in the requests being tested. This is needed for loopback tests of `User.create` to pass valid User data in order to prevent 422 validation error.

This is a follow-up for #12.

/to @ritch please review
/cc @karlmikko
