### PR TITLE
helpers: fix usage of mocha contexts

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -160,7 +160,7 @@ _describe.whenCalledRemotely = function(verb, url, cb) {
       if(methodForVerb === 'delete') methodForVerb = 'del';
 
       this.http = this.request[methodForVerb](this.url);
-      this.url = undefined;
+      delete this.url;
       this.http.set('Accept', 'application/json');
       if(this.loggedInAccessToken) {
         this.http.set('authorization', this.loggedInAccessToken.id);
@@ -170,7 +170,7 @@ _describe.whenCalledRemotely = function(verb, url, cb) {
       this.http.end(function(err) {
         test.req = test.http.req;
         test.res = test.http.res;
-        test.url = undefined;
+        delete test.url;
         cb();
       });
     });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Ritchie Martori",
   "dependencies": {
     "supertest": "~0.9.0",
-    "mocha": "~1.17.1",
+    "mocha": "~1.20.1",
     "async": "~0.2.10"
   },
   "peerDependencies": {


### PR DESCRIPTION
Mocha 1.19 introduced nested contexts, where each `describe` has its
own context inheriting from parent's context via prototype.

The helper `whenCalledRemotely` was reading `this.url` to allow
users to override the url. However, since `whenCalledRemotely` was
not clearing `this.url` properly at the end of the test, the override
worked for the first request only. Subsequent requests used the same
URL as provided in the helper parameters.

This commit fixes the problem by changing `this.url = undefined`
to `delete this.url`, so that the the sub-sequent calls can access
`this.__proto__.url` in the same way as the first call.

/cc @ritch @raymondfeng FYI
