### PR TITLE
Add the ability to intercept requests before they actually get sent

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,11 +82,11 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
     assert(model.dataSource, 'cannot test model '+ modelName
       + ' without attached dataSource');
     assert(
-      typeof model.create === 'function',
-      modelName + ' does not have a create method'
+      typeof model.upsert === 'function',
+      modelName + ' does not have an upsert method'
     );
 
-    model.create(attrs, function(err, result) {
+    model.upsert(attrs, function(err, result) {
       if(err) {
         console.error(err.message);
         if(err.details) console.error(err.details);


### PR DESCRIPTION
I needed to add a body to requests.  LMK if there is an existing way to do it, this is what I came up with.  The last argument to `whenCalledRemotely`, and therefore all the functions which wrap it, can now be an object with `callback` and `beforeRequest` options.

This is fully backwards compatible when you pass a callback as before.  When you use the new option, usage becomes:

``` coffeescript
lt.describe.whenCalledByUser USER, 'PUT', '/apps',
  beforeRequest: ->
    @http.send({orgId: 5})
  callback: ->
    lt.it.shouldBeDenied()
```
