### PR TITLE
Allow another name convention for User model and AccessToken model

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,14 +6,17 @@ var helpers = exports = module.exports = {
   it: _it,
   beforeEach: _beforeEach
 };
+var _ = require('lodash');
 var assert = require('assert');
 var request = require('supertest');
 var expect = require('chai').expect;
 
-_beforeEach.withApp = function(app) {
-  if (app.models.User) {
+_beforeEach.withApp = function(app, options) {
+  options = _.extend({ User: 'User', AccessToken: 'AccessToken' }, options);
+
+  if (app.models[options.User]) {
     // Speed up the password hashing algorithm
-    app.models.User.settings.saltWorkFactor = 4;
+    app.models[options.User].settings.saltWorkFactor = 4;
   }
 
   beforeEach(function() {
@@ -23,6 +26,7 @@ _beforeEach.withApp = function(app) {
     this.get = _request.get;
     this.put = _request.put;
     this.del = _request.del;
+    this.options = options;
   });
 }
 
@@ -77,7 +81,7 @@ _beforeEach.withArgs = function() {
 }
 
 _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
-  var modelKey = modelName;
+  var modelKey = _.camelCase(modelName);
 
   if(typeof attrs === 'function') {
     optionalHandler = attrs;
@@ -93,6 +97,7 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
   beforeEach(function(done) {
     var test = this;
     var app = this.app;
+    modelName = _.capitalize(_.camelCase(this.options[modelName] || modelName));
     var model = app.models[modelName];
     assert(model, 'cannot get model of name ' + modelName + ' from app.models');
     assert(model.dataSource, 'cannot test model '+ modelName
@@ -108,7 +113,7 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
         if(err.details) console.error(err.details);
         done(err);
       } else {
-        test[modelKey] = result;
+        test[modelKey] = test[_.kebabCase(modelKey)] = result;
         done();
       }
     });
@@ -124,8 +129,8 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
 }
 
 _beforeEach.givenUser = function(attrs, optionalHandler) {
-  _beforeEach.givenModel('user', attrs, optionalHandler);
-} 
+  _beforeEach.givenModel('User', attrs, optionalHandler);
+}
 
 _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
   _beforeEach.givenUser(attrs, function (done) {
@@ -222,11 +227,11 @@ _beforeEach.givenLoggedInUserWithRole = function(credentials, role, optionalHand
 }
 
 _beforeEach.givenAnUnauthenticatedToken = function(attrs, optionalHandler) {
-  _beforeEach.givenModel('accessToken', attrs, optionalHandler);
+  _beforeEach.givenModel('AccessToken', attrs, optionalHandler);
 }
 
 _beforeEach.givenAnAnonymousToken = function(attrs, optionalHandler) {
-  _beforeEach.givenModel('accessToken', {id: '$anonymous'}, optionalHandler);
+  _beforeEach.givenModel('AccessToken', {id: '$anonymous'}, optionalHandler);
 }
 
 _describe.whenCalledRemotely = function(verb, url, data, cb) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "chai": "^1.9.2",
+    "lodash": "^3.5.0",
     "mocha": "~1.21.4",
     "supertest": "~0.13.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,7 @@ describe('helpers', function () {
     it('should have an xxx-test-model property', function () {
       assert(this['xxx-test-model']);
       assert(this['xxx-test-model'].id);
+      assert(this['xxx-test-model'] instanceof testModel);
     });
   });
 
@@ -106,6 +107,44 @@ describe('helpers', function () {
         it('should not find the given model', function () {
           assert.equal(this.res.statusCode, 404);
         });
+      });
+    });
+  });
+
+  describe('helpers.beforeEach.givenUser', function() {
+    describe('with default user model', function() {
+      testApp.model(loopback.User, {dataSource: 'db'});
+      helpers.beforeEach.givenUser({ email: 'john@doe.com', password: '000000' });
+      it('should create an user of User type', function () {
+        assert(this['user'] instanceof loopback.User);
+      });
+    });
+    describe('with custom User model', function() {
+      var Account = loopback.User.extend('Account');
+      testApp.model(Account, {dataSource: 'db'});
+      helpers.beforeEach.withApp(testApp, { User: 'Account' });
+      helpers.beforeEach.givenUser({ email: 'john@doe.com', password: '000000' });
+      it('should create an user of Account type', function () {
+        assert(this.user instanceof Account);
+      });
+    });
+  });
+
+  describe('helpers.beforeEach.givenAnUnauthenticatedToken', function() {
+    describe('with default AccessToken model', function() {
+      testApp.model(loopback.AccessToken, {dataSource: 'db'});
+      helpers.beforeEach.givenAnUnauthenticatedToken({});
+      it('should create an accessToken of AccessToken type', function () {
+        assert(this.accessToken instanceof loopback.AccessToken);
+      });
+    });
+    describe('with custom AccessToken model', function() {
+      var Token = loopback.AccessToken.extend('Token');
+      testApp.model(Token, {dataSource: 'db'});
+      helpers.beforeEach.withApp(testApp, { AccessToken: 'Token' });
+      helpers.beforeEach.givenAnUnauthenticatedToken({});
+      it('should create an accessToken of Token type', function () {
+        assert(this.accessToken instanceof Token);
       });
     });
   });


### PR DESCRIPTION
If project doesn't extend built-in models **User** and 
**AccessToken** as **user** and **accessToken**, `givenModel()`
can NOT find these models by keys `user` and `accessToken` via
`app.models[key]`.

By classify the modelName, `givenModel()` can always find the
proper built-in model.

Note: When `user` model extends `User` model, it will register
 both `user` and `User` to `app.models`.

~~FYI: This doesn't fix the case of extending **User** model with 
other name (e.g. **Account**),  and **AccessToken** also.~~

Signed-off-by: Clark Wang clark.wangs@gmail.com
