### PR TITLE
Throw err when beforeEach.withApp is not called

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -236,6 +236,10 @@ _describe.whenCalledRemotely = function(verb, url, data, cb) {
       var methodForVerb = verb.toLowerCase();
       if(methodForVerb === 'delete') methodForVerb = 'del';
 
+      if (this.request === undefined) {
+          throw new Error('App is not specified. Please use lt.beforeEach.withApp to specify the app.');
+      }
+
       this.http = this.request[methodForVerb](this.url);
       delete this.url;
       this.http.set('Accept', 'application/json');


### PR DESCRIPTION
The error that is thrown when lt.beforeEach.withApp is called is cryptic and new users of this module, may not understand what's going on.