### PR TITLE
Add clean datasource feature

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -27,13 +27,17 @@ _beforeEach.withApp = function(app) {
 }
 
 _beforeEach.cleanDatasource = function(dsName) {
-  beforeEach(function() {
+  beforeEach(function(done) {
     if(!dsName) dsName = 'db';
 
-    if (this.app) {
+    if (typeof this.app === 'function'
+        && typeof this.app.datasources === 'object'
+        && typeof this.app.datasources[dsName] === 'object') {
       this.app.datasources[dsName].automigrate();
       this.app.datasources[dsName].connector.ids = {};
     }
+    
+    done();
   });
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,6 +26,17 @@ _beforeEach.withApp = function(app) {
   });
 }
 
+_beforeEach.cleanDatasource = function(dsName) {
+  beforeEach(function() {
+    if(!dsName) dsName = 'db';
+
+    if (this.app) {
+      this.app.datasources[dsName].automigrate();
+      this.app.datasources[dsName].connector.ids = {};
+    }
+  });
+}
+
 function mixin(obj, into) {
   Object.keys(obj).forEach(function(key) {
     if(typeof obj[key] === 'function') {

--- a/test/test.js
+++ b/test/test.js
@@ -86,4 +86,27 @@ describe('helpers', function () {
       });
     });
   });
+
+  describe('cleanDatasource', function() {
+    helpers.describe.staticMethod('create', function() {
+      helpers.beforeEach.withArgs({foo: 'bar'});
+      helpers.describe.whenCalledRemotely('POST', '/xxx-test-models', function() {
+        it('should call the method over rest', function () {
+          assert.equal(this.res.statusCode, 200);
+        });
+      });
+    });
+
+    helpers.describe.staticMethod('findById', function() {
+      helpers.beforeEach.givenModel('xxx-test-model', {foo: 'bar'});
+      helpers.beforeEach.cleanDatasource();
+      helpers.describe.whenCalledRemotely('GET', function () {
+        return '/xxx-test-models/' + this['xxx-test-model'].id;
+      }, function() {
+        it('should not find the given model', function () {
+          assert.equal(this.res.statusCode, 404);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add the helper to clean the datasource before running the next commands.

- Had to use beforeEach because of the `whenCalledRemotely` being called `beforeEach`