### PR TITLE
Ensure that a generated string value is not longer than the property's specified length

### DIFF
--- a/lib/test-data-builder.js
+++ b/lib/test-data-builder.js
@@ -120,7 +120,16 @@ TestDataBuilder.prototype._gatherDefaultPropertyValues = function(Model) {
 
     switch (prop.type) {
       case String:
-        result[name] = 'a test ' + name + ' #' + (++valueCounter);
+        var generatedString = 'a test ' + name + ' #' + (++valueCounter);
+
+        // If this property has a maximum length, ensure that the generated
+        // string is not longer than the property's max length
+        if (prop.length) {
+          // Chop off the front part of the string so it is equal to the length
+          generatedString = generatedString.substring(
+            generatedString.length - prop.length);
+        }
+        result[name] = generatedString;
         break;
       case Number:
         result[name] = 1230000 + (++valueCounter);

--- a/test/test-data-builder.test.js
+++ b/test/test-data-builder.test.js
@@ -48,6 +48,23 @@ describe('TestDataBuilder', function() {
   itAutoFillsRequiredPropertiesWithUniqueValuesFor(Number);
   itAutoFillsRequiredPropertiesWithUniqueValuesFor(Date);
 
+  it('limits the length of the generated string value to the property length', function(done) {
+    var testMaxStringLength = 10;
+    givenTestModel({
+      required1: { type: String, required: true },
+      required2: { type: String, required: true, length: testMaxStringLength }
+    });
+
+    new TestDataBuilder()
+      .define('model', TestModel, {})
+      .buildTo(this, function(err) {
+        if (err) return done(err);
+        expect(this.model.required1).to.not.equal(this.model.required2);
+        expect(this.model.required2).to.have.length.of.at.most(testMaxStringLength);
+        done();
+      }.bind(this));
+  });
+
   it('auto-fills required Boolean properties with false', function(done) {
     givenTestModel({
       required: { type: Boolean, required: true }


### PR DESCRIPTION
This is to fix an issue where a database might have a longer property name and a small varchar field to put the generated string into. The test data builder was not respecting the model's property length, so now it chops off enough of the left portion of the generated string so the data will fit in the column. Also added a test for this condition.