### PR TITLE
use findorCreate to create roles

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -130,7 +130,7 @@ _beforeEach.givenUser = function(attrs, optionalHandler) {
 _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
   _beforeEach.givenUser(attrs, function (done) {
     var test = this;
-    test.app.models.Role.create({name: role}, function (err, result) {
+    test.app.models.Role.findOrCreate({name: role}, function (err, result) {
       if(err) {
         console.error(err.message);
         if(err.details) console.error(err.details);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -239,11 +239,17 @@ _describe.whenCalledRemotely = function(verb, url, data, cb) {
   if(typeof url === 'function') {
     urlStr = '/<dynamic>';
   }
+  else if(typeof url === 'object' && url.hasOwnProperty('placeHolder')) {
+    urlStr = url.placeHolder;
+  }
 
   describe(verb.toUpperCase() + ' ' + urlStr, function() {
     beforeEach(function(cb) {
       if(typeof url === 'function') {
         this.url = url.call(this);
+      }
+      else if(typeof url === 'object' && url.hasOwnProperty('callback')){
+        this.url = url.callback.call(this);
       }
       this.remotely = true;
       this.verb = verb.toUpperCase();


### PR DESCRIPTION
The Role creation helper creates a new/duplicate role everytime even if it is of the same name. However, this is not very helpful. Role names should be unique. Also, in a system where there are pre-created roles like 'admin', I think that findOrCreate works better. Please merge this if you think this is a legit argument.