### PR TITLE
Replace call of login method on constructor

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -194,7 +194,7 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
 _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
   _beforeEach.givenUser(credentials, function(done) {
     var test = this;
-    this.app.models[this.userModel].constructor.login(credentials, function(err, token) {
+    this.app.models[this.userModel].login(credentials, function(err, token) {
       if(err) {
         done(err);
       } else {
@@ -217,7 +217,7 @@ _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
 _beforeEach.givenLoggedInUserWithRole = function(credentials, role, optionalHandler){
   _beforeEach.givenUserWithRole(credentials, role, function(done) {
     var test = this;
-    this.app.models[this.userModel].constructor.login(credentials, function(err, token) {
+    this.app.models[this.userModel].login(credentials, function(err, token) {
       if(err) {
         done(err);
       } else {


### PR DESCRIPTION
Replace call of login method on constructor. Besides that it fixes error messages like TypeError: undefined is not a function.