### PR TITLE
Fix bugs in givenUser/WithRole when combined withUserModel helper

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -92,7 +92,8 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
 
   beforeEach(function(done) {
     if(modelName === '__USERMODEL__') {
-      modelName = this.userModel ? this.userModel : 'user';
+      modelName = this.userModel ? this.userModel : 'User';
+      modelKey = modelName;
     }
 
     var test = this;
@@ -146,7 +147,7 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
   }
   _beforeEach.givenUser(attrs, function (done) {
     var test = this;
-    test.app.models.Role.findOrCreate({name: role}, function (err, result) {
+    test.app.models.Role.findOrCreate(role, function (err, result) {
       if(err) {
         console.error(err.message);
         if(err.details) console.error(err.details);
@@ -154,9 +155,10 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
       }
 
       test.userRole = result;
-      test.app.models.roleMapping.create(
-        {principalId: test.user.id,
-         principalType: test.app.models.roleMapping.USER,
+      var userModelName = test.userModel ? test.userModel : '__USERMODEL__';
+      test.app.models.RoleMapping.create(
+        {principalId: test[userModelName].id,
+         principalType: test.app.models.RoleMapping.USER,
          roleId: result.id},
         function (err, result) {
           if(err) {
@@ -194,7 +196,7 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
 _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
   _beforeEach.givenUser(credentials, function(done) {
     var test = this;
-    this.app.models[this.userModel].constructor.login(credentials, function(err, token) {
+    this.app.models[this.userModel].login(credentials, function(err, token) {
       if(err) {
         done(err);
       } else {
@@ -217,7 +219,7 @@ _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
 _beforeEach.givenLoggedInUserWithRole = function(credentials, role, optionalHandler){
   _beforeEach.givenUserWithRole(credentials, role, function(done) {
     var test = this;
-    this.app.models[this.userModel].constructor.login(credentials, function(err, token) {
+    this.app.models[this.userModel].login(credentials, function(err, token) {
       if(err) {
         done(err);
       } else {

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,8 @@ describe('helpers', function () {
   var testApp = loopback();
   var db = testApp.dataSource('db', {connector: loopback.Memory});
   var testModel = testApp.model('xxx-test-model', {dataSource: 'db'});
+  testApp.model(loopback.Role, { dataSource: 'db'});
+  testApp.model(loopback.RoleMapping, { dataSource: 'db'});
 
   testApp.use(loopback.rest());
   helpers.beforeEach.withApp(testApp);
@@ -106,6 +108,30 @@ describe('helpers', function () {
         it('should not find the given model', function () {
           assert.equal(this.res.statusCode, 404);
         });
+      });
+    });
+  });
+
+  describe('withUserModel', function() {
+    helpers.beforeEach.withUserModel('xxx-test-model');
+    it("should set the user model name", function() {
+      assert.equal(this.userModel, 'xxx-test-model');
+    });
+
+    describe('givenUser', function() {
+      helpers.beforeEach.givenUser();
+      it("should create a new instance of specified User model", function() {
+        assert(this[this.userModel]);
+      });
+    });
+
+    describe('givenUserWithRole', function() {
+      helpers.beforeEach.givenUserWithRole({id: 1}, {id: 2, name: "testRole"});
+      it("should create a user instance (of specified User model) with the given role", function() {
+        assert.equal(this[this.userModel].id, 1);
+        assert.equal(this.userRole.id, 2);
+        assert.equal(this.userRole.name, "testRole");
+        assert(this.userRoleMapping);
       });
     });
   });


### PR DESCRIPTION
Summary:
 - Added tests to verify combined of withUserModel and givenUser (& givenUserWithRole). These failed previously.
 - Changed default User model to "User" instead of "user".
 - Removed "constructor" in User.login invocations.
 - Role.findOrCreate was incorrectly double-nesting the role-name. {name: {name: "testRole"} }