### PR TITLE
Add support for non-default models

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -15,6 +15,11 @@ var assert = require('assert');
 var request = require('supertest');
 var expect = require('chai').expect;
 
+var DEFAULT_USER_MODEL = 'user';
+var DEFAULT_ACCESS_TOKEN_MODEL = 'accessToken';
+var DEFAULT_ROLE_MODEL = 'Role';
+var DEFAULT_ROLE_MAPPING_MODEL = 'roleMapping';
+
 _beforeEach.withApp = function(app) {
   if (app.models.User) {
     // Speed up the password hashing algorithm
@@ -82,7 +87,7 @@ _beforeEach.withArgs = function() {
 }
 
 _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
-  var modelKey = modelName;
+  var modelKey;
 
   if(typeof attrs === 'function') {
     optionalHandler = attrs;
@@ -96,9 +101,16 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
   attrs = attrs || {};
 
   beforeEach(function(done) {
-    if(modelName === '__USERMODEL__') {
-      modelName = this.userModel ? this.userModel : 'user';
+
+    if (modelName === '__USERMODEL__') {
+      modelName = this.userModel ?
+        this.userModel : DEFAULT_USER_MODEL;
+    } else if (modelName === '__ACCESSTOKENMODEL__') {
+      modelName = this.accessTokenModel ?
+        this.accessTokenModel : DEFAULT_ACCESS_TOKEN_MODEL;
     }
+
+    modelKey = modelName;
 
     var test = this;
     var app = this.app;
@@ -139,6 +151,27 @@ _beforeEach.withUserModel = function(model) {
   });
 };
 
+_beforeEach.withAccessTokenModel = function(model) {
+  beforeEach(function(done) {
+    this.accessTokenModel = model;
+    done();
+  });
+};
+
+_beforeEach.withRoleModel = function(model) {
+  beforeEach(function(done) {
+    this.roleModel = model;
+    done();
+  });
+};
+
+_beforeEach.withRoleMappingModel = function(model) {
+  beforeEach(function(done) {
+    this.roleMappingModel = model;
+    done();
+  });
+};
+
 _beforeEach.givenUser = function(attrs, optionalHandler) {
   _beforeEach.givenModel('__USERMODEL__', attrs, optionalHandler);
 }
@@ -151,7 +184,18 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
   }
   _beforeEach.givenUser(attrs, function (done) {
     var test = this;
-    test.app.models.Role.findOrCreate({name: role}, function (err, result) {
+
+    var roleModelName = test.roleModel ?
+      test.roleModel : DEFAULT_ROLE_MODEL;
+
+    var Role = test.app.models[roleModelName];
+
+    if (!Role) {
+      return done('Role model with name ' +
+        roleModelName + ' not found');
+    }
+
+    Role.findOrCreate(role, function (err, result) {
       if(err) {
         console.error(err.message);
         if(err.details) console.error(err.details);
@@ -159,9 +203,23 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
       }
 
       test.userRole = result;
-      test.app.models.roleMapping.create(
-        {principalId: test.user.id,
-         principalType: test.app.models.roleMapping.USER,
+
+      var roleMappingModelName = test.roleMappingModel ?
+        test.roleMappingModel : DEFAULT_ROLE_MAPPING_MODEL;
+
+      var userModelName = test.userModel ?
+        test.userModel : DEFAULT_USER_MODEL;
+
+      var RoleMapping = test.app.models[roleMappingModelName];
+
+      if (!RoleMapping) {
+        return done('RoleMapping model with name ' +
+          roleMappingModelName + ' not found');
+      }
+
+      RoleMapping.create(
+        {principalId: test[userModelName].id,
+         principalType: RoleMapping.USER,
          roleId: result.id},
         function (err, result) {
           if(err) {
@@ -169,7 +227,7 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
             if(err.details) console.error(err.details);
             return done(err);
           }
-    
+
           test.userRoleMapping = result;
           done();
         }
@@ -199,7 +257,18 @@ _beforeEach.givenUserWithRole = function (attrs, role, optionalHandler) {
 _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
   _beforeEach.givenUser(credentials, function(done) {
     var test = this;
-    this.app.models[this.userModel].login(credentials, function(err, token) {
+
+    var userModelName = this.userModel ?
+      this.userModel : DEFAULT_USER_MODEL;
+
+    var User = test.app.models[userModelName];
+
+    if (!User) {
+      return done('User model with name ' +
+        userModelName + ' not found');
+    }
+
+    User.login(credentials, function(err, token) {
       if(err) {
         done(err);
       } else {
@@ -222,7 +291,18 @@ _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
 _beforeEach.givenLoggedInUserWithRole = function(credentials, role, optionalHandler){
   _beforeEach.givenUserWithRole(credentials, role, function(done) {
     var test = this;
-    this.app.models[this.userModel].login(credentials, function(err, token) {
+
+    var userModelName = test.userModel ?
+      test.userModel : DEFAULT_USER_MODEL;
+
+    var User = test.app.models[userModelName];
+
+    if (!User) {
+      return done('User model with name ' +
+        userModelName + ' not found');
+    }
+
+    User.login(credentials, function(err, token) {
       if(err) {
         done(err);
       } else {
@@ -243,11 +323,11 @@ _beforeEach.givenLoggedInUserWithRole = function(credentials, role, optionalHand
 }
 
 _beforeEach.givenAnUnauthenticatedToken = function(attrs, optionalHandler) {
-  _beforeEach.givenModel('AccessToken', attrs, optionalHandler);
+  _beforeEach.givenModel('__ACCESSTOKENMODEL__', attrs, optionalHandler);
 }
 
 _beforeEach.givenAnAnonymousToken = function(attrs, optionalHandler) {
-  _beforeEach.givenModel('AccessToken', {id: '$anonymous'}, optionalHandler);
+  _beforeEach.givenModel('__ACCESSTOKENMODEL__', {id: '$anonymous'}, optionalHandler);
 }
 
 _describe.whenCalledRemotely = function(verb, url, data, cb) {
@@ -333,7 +413,7 @@ _describe.whenCalledByUserWithRole = function (credentials, role, verb, url, dat
    describe('when called by logged in user with role ' + role, function () {
     _beforeEach.givenLoggedInUserWithRole(credentials, role);
     _describe.whenCalledRemotely(verb, url, data, cb);
-  }); 
+  });
 }
 
 _describe.whenCalledAnonymously = function(verb, url, data, cb) {

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,9 @@ describe('helpers', function () {
      'shouldBeAllowedWhenCalledUnauthenticated',
      'shouldBeDeniedWhenCalledUnauthenticated',
      'shouldBeAllowedWhenCalledByUser',
-     'shouldBeDeniedWhenCalledByUser']
+     'shouldBeDeniedWhenCalledByUser',
+     'shouldBeAllowedWhenCalledByUserWithRole',
+     'shouldBeDeniedWhenCalledByUserWithRole']
     .forEach(function(func) {
       it('should have a method named ' + func, function () {
         assert.equal(typeof helpers.it[func], 'function');
@@ -35,8 +37,11 @@ describe('helpers', function () {
   describe('helpers.describe', function() {
     ['staticMethod',
      'instanceMethod',
+     'whenCalledRemotely',
      'whenLoggedInAsUser',
+     'whenLoggedInAsUserWithRole',
      'whenCalledByUser',
+     'whenCalledByUserWithRole',
      'whenCalledAnonymously',
      'whenCalledUnauthenticated']
     .forEach(function(func) {
@@ -47,10 +52,18 @@ describe('helpers', function () {
   });
 
   describe('helpers.beforeEach', function() {
-    ['withArgs',
+    ['withApp',
+     'cleanDatasource',
+     'withArgs',
      'givenModel',
+     'withUserModel',
+     'withAccessTokenModel',
+     'withRoleModel',
+     'withRoleMappingModel',
      'givenUser',
+     'givenUserWithRole',
      'givenLoggedInUser',
+     'givenLoggedInUserWithRole',
      'givenAnUnauthenticatedToken',
      'givenAnAnonymousToken']
     .forEach(function(func) {


### PR DESCRIPTION
NOTE: this is an updated version of #57 that has been rebased off the current master branch as well as fixing the issue noted at https://github.com/strongloop-archive/loopback-testing/pull/57#r41110725

----------

Default functionality has not changed, but the models
that the helpers will use can be customized with beforeEach
hooks. Default model names are also clarified by adding
constant strings to the top of the helper file.

- Update support for custom User model

- Add support for custom AccessToken, Role, and RoleMapping model

- Add check if models exist before referencing them

- Use User.login instead of User.constructor.login

- Add new and missing helper methods to helper test